### PR TITLE
add `with-peruserlimits`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [1.0.51-r28] · 2024-08-29
+[1.0.51-r28]: /../../tree/1.0.51-r28
+
+[Diff](/../../compare/1.0.51-r27...1.0.51-r28)
+
+### Added
+
+- `PER_USER_LIMITS` support. ([#7])
+
+[#7]: /../../pull/7
+
+
+
+
 ## [1.0.51-r27] · 2024-07-26
 [1.0.51-r27]: /../../tree/1.0.51-r27
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.20
 
 ARG pure_ftpd_ver=1.0.51
 ARG s6_overlay_ver=3.2.0.0
-ARG build_rev=27
+ARG build_rev=28
 
 
 # Build and install Pure-FTPd
@@ -37,13 +37,13 @@ RUN apk update \
     \
  # Build Pure-FTPd from sources
  && ./configure --prefix=/usr \
+        --with-peruserlimits \
         --with-puredb \
         --with-quotas \
         --with-ratios \
         --with-rfc2640 \
         --with-throttling  \
         --with-tls \
-        --with-peruserlimits \
         --without-capabilities \
         --without-humor \
         --without-inetd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,12 +37,15 @@ RUN apk update \
     \
  # Build Pure-FTPd from sources
  && ./configure --prefix=/usr \
+        --sysconfdir=/etc/pure-ftpd \
+        --localstatedir=/var/pure-ftpd \
         --with-puredb \
         --with-quotas \
         --with-ratios \
         --with-rfc2640 \
         --with-throttling  \
         --with-tls \
+        --with-peruserlimits \
         --without-capabilities \
         --without-humor \
         --without-inetd \
@@ -61,7 +64,7 @@ RUN apk update \
  && install -d -o pure-ftpd -g pure-ftpd /data \
  # Disable daemonization
  && sed -i -e 's,^Daemonize .*,Daemonize no,' \
-        /etc/pure-ftpd.conf \
+        /etc/pure-ftpd/pure-ftpd.conf \
  # No documentation included to keep image size smaller
  && rm -rf /usr/share/man/* \
     \
@@ -102,4 +105,4 @@ EXPOSE 21 30000-30009
 
 ENTRYPOINT ["/init"]
 
-CMD ["pure-ftpd", "/etc/pure-ftpd.conf"]
+CMD ["pure-ftpd", "/etc/pure-ftpd/pure-ftpd.conf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,6 @@ RUN apk update \
     \
  # Build Pure-FTPd from sources
  && ./configure --prefix=/usr \
-        --sysconfdir=/etc/pure-ftpd \
-        --localstatedir=/var/pure-ftpd \
         --with-puredb \
         --with-quotas \
         --with-ratios \
@@ -64,7 +62,7 @@ RUN apk update \
  && install -d -o pure-ftpd -g pure-ftpd /data \
  # Disable daemonization
  && sed -i -e 's,^Daemonize .*,Daemonize no,' \
-        /etc/pure-ftpd/pure-ftpd.conf \
+        /etc/pure-ftpd.conf \
  # No documentation included to keep image size smaller
  && rm -rf /usr/share/man/* \
     \
@@ -105,4 +103,4 @@ EXPOSE 21 30000-30009
 
 ENTRYPOINT ["/init"]
 
-CMD ["pure-ftpd", "/etc/pure-ftpd/pure-ftpd.conf"]
+CMD ["pure-ftpd", "/etc/pure-ftpd.conf"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Pure-FTPd Docker image
 
 ## Supported tags and respective `Dockerfile` links
 
-- [`1.0.51-r27`, `1.0.51`, `1.0`, `1`, `latest`][201]
+- [`1.0.51-r28`, `1.0.51`, `1.0`, `1`, `latest`][201]
 
 
 
@@ -44,7 +44,7 @@ docker run -d -p 21:21 -p 30000-30009:30000-30009 instrumentisto/pure-ftpd
 
 
 ### Why so many ports opened?
-    
+
 This is for `PASV` support, please see: [#5 PASV not fun :)][12]
 
 


### PR DESCRIPTION
hi, thanks for the base image!

~~this separates out the configuration from the image's `/etc` and `/var` locations to allow for simpler volume mounting (e.g. for persisting configuration and user accounts).~~ removed as discussed

this adds with-peruserlimits to support the PER_USER_LIMITS property that is useful for allowing more than 20 anonymous connections